### PR TITLE
Load balaner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,9 @@ services:
       dockerfile: Dockerfile
     restart: always  
     ports:
-      - "80:80"
+      - "8080:80"
     stdin_open: true 
     tty: true
-    # volumes:
-    #   - /server-a/Volumes/static:/index
-    #   - /server-a/nginx.conf:/etc/nginx/conf.d/default.conf
-
 
   server-b:
     container_name: server-b
@@ -23,7 +19,7 @@ services:
       dockerfile: Dockerfile
     restart: always  
     ports:
-      - "80:80"
+      - "8081:80"
     stdin_open: true 
     tty: true
   load-balancer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     build:
       context: ./load-balancer
       dockerfile: Dockerfile
+    ports:
+      - "60000-65000:60000-65000"
     stdin_open: true 
     tty: true    
     depends_on:

--- a/load-balancer/Dockerfile
+++ b/load-balancer/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+
+WORKDIR /load-balancer/load-balancer
+
+COPY ./nginx.conf /etc/nginx/nginx.conf 

--- a/load-balancer/nginx.conf
+++ b/load-balancer/nginx.conf
@@ -1,0 +1,24 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream backend {
+        ip_hash; # Use the ip_hash load balancing method, ensure sticky session
+        server server-a:80;
+        server server-b:80;
+    }
+
+    server {
+        listen 60000-65000;
+        
+        server_name load-balancer;
+
+        location / {
+            proxy_pass http://backend;
+            proxy_set_header Host $host; #typically contains the domain name of the server to which the client is trying to connect
+            proxy_set_header X-Real-IP $remote_addr; #pass the original client's IP address to the backend servers
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; #keep track of the client's IP address and all intermediate proxies' IP addresses between the client and the load balancer.
+        }
+    }
+}

--- a/load-balancer/nginx.conf
+++ b/load-balancer/nginx.conf
@@ -1,6 +1,6 @@
 events {
-    worker_connections 1024;
-}
+    worker_connections 20004; # needs to be at least 1004 with 5001 sockets open
+} # this number is a bit trial ad error
 
 http {
     upstream backend {
@@ -11,6 +11,7 @@ http {
 
     server {
         listen 60000-65000;
+        listen [::]:60000-65000;
         
         server_name load-balancer;
 

--- a/server-b/nginx.conf
+++ b/server-b/nginx.conf
@@ -1,19 +1,19 @@
-events {
-    worker_connections 1024;
+events { #handles connections and events in Nginx
+    worker_connections 1024; #sets the maximum number of connections that each worker process can handle simultaneously
 }
 
 http {
-    include mime.types;
-    sendfile on;
+    include mime.types; #defines the mapping of file extensions to MIME types
+    sendfile on; #enables the use of the operating system's sendfile syscall for serving static files efficiently
 
     server {
         listen 80;
-        listen [::]:80;
+        listen [::]:80; #listen on port 80 for both IPv4 and IPv6 connections
 
-        resolver 127.0.0.11;
-        autoindex off;
+        resolver 127.0.0.11; #This IP address is commonly used in Docker containers as the DNS resolver for containers connected to the default Docker bridge network
+        autoindex off; #prevent directory listings and ensure that only files with valid index files are served, setting autoindex off; is a good security practice.
 
-        server_name server-b;;
+        server_name server-b;
         server_tokens off;
 
         root /usr/share/nginx/html/;


### PR DESCRIPTION
## Update Docker Compose and Nginx Configuration to implement Load Balancer

This pull request (PR) updates the Docker Compose and Nginx configuration to improve container management and load balancing. The changes include:

1. Docker Compose Updates:
   - Renamed server container labels for consistency (e.g., `server-a` -> `server-a`)
   - Modified port mappings to avoid conflicts (e.g., `80:80` -> `8080:80` for `server-a`, `80:80` -> `8081:80` for `server-b`)
   - Added port range `60000-65000` mapping for the load balancer (`load-balancer`) to enable sticky session support.

2. Nginx Configuration:
   - Added a new `nginx.conf` file for the load balancer (`load-balancer`) with `ip_hash` load balancing and sticky session implementation.
   - Configured the load balancer to listen on ports `60000-65000` and direct traffic to backend servers `server-a` and `server-b`.

3. Other Updates:
   - Included a blank Dockerfile for the `nagios-monitor` service.
   - Improved the make commands' descriptions for better clarity.